### PR TITLE
turn 인자 추가 + GameMessage 객체를 구조분해할당 가능하도록 수정.

### DIFF
--- a/Runners/Python/PyHost/models/game_message.py
+++ b/Runners/Python/PyHost/models/game_message.py
@@ -2,6 +2,11 @@ from pydantic import BaseModel
 from typing import List
 
 class GameMessage(BaseModel):
+    turn: int
     position: int
     map: List[int]
     current: int
+
+    # __iter__를 정의
+    def __iter__(self):
+        return iter((self.turn, self.position, self.map, self.current))

--- a/Runners/Python/PyHost/services/game_service.py
+++ b/Runners/Python/PyHost/services/game_service.py
@@ -36,7 +36,7 @@ class GameService:
 
     async def move_next(self, message, cancellation_token=None):
         try:
-            position, map_data, current = message
+            turn, position, map_data, current = message
 
             return await asyncio.to_thread(self._move_next_sync, position, map_data, current)
         except Exception as ex:


### PR DESCRIPTION
```
turn, position, map_data, current = message
```
검색해보니 초반 message 할당은 구조 분해할당이 불가능해야 정상이라고 하네요.(Pydantic 타입은 구조분해할당이 불가능하답니다.)

요거 아마 기존에 실행이 안 되어야 정상일 텐데 왜 가능했는 지는 모르겠네요.

구조분해할당이 가능하도록 GameMessage 에 `__iter__` 를 정의했고 
실제 게임에서 전달하는 추가 인자인 turn 값도 추가해뒀습니다.

확인 부탁드려요.