### PR TITLE
응답 형식을 수정합니다.

### DIFF
--- a/Runners/Python/PyHost/routes/game.py
+++ b/Runners/Python/PyHost/routes/game.py
@@ -1,5 +1,5 @@
 from fastapi import Request , APIRouter, Depends, Query, HTTPException, BackgroundTasks
-from fastapi.responses import JSONResponse
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 from PyHost.services.game_service import GameService
 from PyHost.services.player_service import PlayerService
@@ -20,13 +20,13 @@ async def get_current_game_set(game_service: GameService = Depends(get_game_serv
 
 @router.get("/healthy")
 async def healthy():
-    return JSONResponse(content="Healthy", status_code=200)
+    return PlainTextResponse(content="Healthy", status_code=200)
 
 @router.post("/set")
 async def set_game(gameId: str = Query(...), column: int = Query(...), row: int = Query(...), game_service: GameService = Depends(get_game_service)):
     try:
         game_service.init_game(gameId, column, row)
-        return JSONResponse(content="Game set successfully", status_code=200)
+        return PlainTextResponse(content="Game set successfully", status_code=200)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -36,9 +36,9 @@ async def shutdown(background_tasks: BackgroundTasks):
         import os
         os._exit(0)
     background_tasks.add_task(stop_app)
-    return JSONResponse(content="Server is shutting down", status_code=200)
+    return PlainTextResponse(content="Server is shutting down", status_code=200)
 
 @router.post("/cleanup")
 async def cleanup(game_service: GameService = Depends(get_game_service)):
     game_service.clean_up()
-    return JSONResponse(content="Clean up successful", status_code=200)
+    return PlainTextResponse(content="Clean up successful", status_code=200)

--- a/Runners/Python/PyHost/routes/player.py
+++ b/Runners/Python/PyHost/routes/player.py
@@ -1,5 +1,6 @@
 from fastapi import Request, APIRouter, Depends, Form, Path, Body, HTTPException
 from fastapi.responses import JSONResponse
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 from typing import Optional
 import asyncio
@@ -25,7 +26,7 @@ async def load_player(
 ):
     try:
         await game_service.load_player(position, filePath)
-        return JSONResponse(content="Player loaded successfully", status_code=200)
+        return PlainTextResponse(content="Player loaded successfully", status_code=200)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -38,7 +39,7 @@ async def initialize_player(
 ):
     try:
         game_service.initialize_player(position, column, row)
-        return JSONResponse(content="Player initialized successfully", status_code=200)
+        return PlainTextResponse(content="Player initialized successfully", status_code=200)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -49,7 +50,7 @@ async def get_player_name(
 ):
     try:
         name = game_service.get_player_name(position)
-        return JSONResponse(content=name, status_code=200)
+        return PlainTextResponse(content=name, status_code=200)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
문자열만 응답하는 api 에서 JSONResponse 를 단독으로 사용할 경우 
응답 받는 측에 `"` 이 포함되어서 응답되는 문제가 있습니다.

예를 들어 getName 에서 `greg` 이라는 문자열만 응답해야하는데 아래 코드를 사용하면
```
name = "greg"
return JSONResponse(content=name, status_code=200)
```

다음과 같이 응답됩니다.
```
\"greg\"
```

단순 문자열만 반환하는 경우 PlainTextResponse 를 통해 문자열만 반환하도록 변경했습니다.

** moveNext 의 경우 int 만 반환하는데 이 int 는 JSONResponse 에 content 에 할당해도 받는 측에서 정상적으로 int 만 처리됩니다.(유지)