### PR TITLE
C#, Python 로그 파일 절대 경로로 수정

### DIFF
--- a/Runners/CSharp/CSharpHost/Program.cs
+++ b/Runners/CSharp/CSharpHost/Program.cs
@@ -13,7 +13,7 @@ if (args.Length > 0)
 }
 
 // load configs(appsettings.json)
-builder.Configuration.AddJsonFile($"./configs/appsettings.json");
+builder.Configuration.AddJsonFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "configs", "appsettings.json"));
 builder.Services.Configure<AppSettings>(builder.Configuration.GetSection(nameof(AppSettings)));
 
 builder.Services.AddTransient<IPlayerLoader, PlayerLoader>();

--- a/Runners/CSharp/CSharpHost/Services/Utils/AppSettingVault.cs
+++ b/Runners/CSharp/CSharpHost/Services/Utils/AppSettingVault.cs
@@ -1,4 +1,5 @@
-﻿using CSharpHost.configs;
+﻿using System.Diagnostics;
+using CSharpHost.configs;
 using CSharpHost.Contracts;
 using Microsoft.Extensions.Options;
 
@@ -9,5 +10,6 @@ public class AppSettingVault(IOptions<AppSettings> options) : IAppSettingVault
     private readonly AppSettings _appSettings = options.Value;
 
     public string GetGameLoggerRootPath()
-        => _appSettings.GameLog?.RootPath ?? throw new Exception("Can not get game logger root path.");
+        => Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+            _appSettings.GameLog?.RootPath ?? throw new Exception("Can not get game logger root path."));
 }

--- a/Runners/CSharp/CSharpHost/configs/appsettings.json
+++ b/Runners/CSharp/CSharpHost/configs/appsettings.json
@@ -1,7 +1,7 @@
 {
   "AppSettings": {
     "GameLog": {
-      "RootPath": "./logs"
+      "RootPath": "logs"
     }
   },
   "Logging": {

--- a/Runners/Python/PyHost/main.py
+++ b/Runners/Python/PyHost/main.py
@@ -6,16 +6,21 @@ from PyHost.services.game_logger import GameLogger
 from PyHost.services.player_service import PlayerService
 from PyHost.services.player_loader import PlayerLoader
 
-import uvicorn
-import argparse
+import uvicorn, os, sys, argparse
 
 app = FastAPI()
 
+def get_current_dir():
+    if getattr(sys, "frozen", False):  # cx_Freeze 환경
+        return os.path.dirname(sys.executable)
+    else:  # 개발 환경 (스크립트 실행)
+        return os.path.dirname(os.path.abspath(__file__))
+    
 @app.on_event("startup")
 async def startup_event():
     player_loader = PlayerLoader()
     player_service = PlayerService(player_loader)
-    game_logger = GameLogger("logs")
+    game_logger = GameLogger(os.path.join(get_current_dir(), "logs"))
     app.state.game_service_instance = GameService(player_service, game_logger)
 
 app.include_router(game.router, prefix="/coinchallenger/py/game", tags=["game"])


### PR DESCRIPTION
C#: 상대경로로 작성된 부분 AppDomain.CurrentDomain.BaseDirectory를 포함해 절대 경로로 수정

Python: cx_Freeze로 실행되는 경우, 스크립트로 실행되는 경우 경로 구하는 방법 다르게해서 절대경로로 로그 파일 쓰도록 수정